### PR TITLE
Single samples

### DIFF
--- a/src/Data/Distribution.hs
+++ b/src/Data/Distribution.hs
@@ -80,6 +80,9 @@ sample env expr = case expr of
         sample' = sample env
         ifThenElse c a b = if c then a else b
 
+samples :: Int -> Env -> Expr a -> IO [a]
+samples n env = sequenceA . replicate n . sample env
+
 histogramFrom :: Real a => a -> a -> [a] -> [Int]
 histogramFrom from width samples
   | null samples = []

--- a/src/Data/Distribution.hs
+++ b/src/Data/Distribution.hs
@@ -73,9 +73,7 @@ sample env expr = case expr of
   Map f a -> f <$> sample' a
   App f a b -> f <$> sample' a <*> sample' b
   Alt a b -> sample' a <|> sample' b
-  Join a -> do
-    a' <- sample' a
-    sample' a'
+  Join a -> sample' a >>= sample'
   where sample' :: Expr a -> IO a
         sample' = sample env
         ifThenElse c a b = if c then a else b

--- a/src/Data/Distribution.hs
+++ b/src/Data/Distribution.hs
@@ -2,7 +2,6 @@
 module Data.Distribution where
 
 import Control.Applicative
-import Control.Monad
 import Data.List (partition, sortOn)
 import Data.Semigroup
 import System.Random
@@ -34,9 +33,9 @@ data Var a where
   Bool :: String -> Var Bool
   Int :: String -> Var Int
 
-type Env = forall a. Var a -> [a]
+type Env = forall a. Var a -> a
 
-lookupEnv :: Env -> Var a -> [a]
+lookupEnv :: Env -> Var a -> a
 lookupEnv = id
 
 emptyEnv :: Env
@@ -44,43 +43,41 @@ emptyEnv (Double v) = error ("unbound double variable " ++ v)
 emptyEnv (Bool v) = error ("unbound bool variable " ++ v)
 emptyEnv (Int v) = error ("unbound int variable " ++ v)
 
-extendEnv :: Var a -> [a] -> Env -> Env
+extendEnv :: Var a -> a -> Env -> Env
 extendEnv (Double v) x _ (Double v') | v == v' = x
 extendEnv (Bool v) x _ (Bool v') | v == v' = x
 extendEnv (Int v) x _ (Int v') | v == v' = x
 extendEnv _ _ env v' = env v'
 
-sample :: Int -> Env -> Expr a -> IO [a]
-sample n env expr
-  | n > 0 = case expr of
-    StdRandom -> traverse getStdRandom (replicate n random)
-    Lit x -> pure (replicate n x)
-    Get v -> pure (lookupEnv env v)
-    Let v e e' -> do
-      x <- sample' e
-      sample n (extendEnv v x env) e'
-    Not e -> fmap not <$> sample' e
-    Neg e -> fmap negate <$> sample' e
-    Abs e -> fmap abs <$> sample' e
-    Sig e -> fmap signum <$> sample' e
-    Exp e -> fmap exp <$> sample' e
-    Log e -> fmap log <$> sample' e
-    Add a b -> zipWith (+) <$> sample' a <*> sample' b
-    Mul a b -> zipWith (*) <$> sample' a <*> sample' b
+sample :: Env -> Expr a -> IO a
+sample env expr = case expr of
+  StdRandom -> getStdRandom random
+  Lit x -> pure x
+  Get v -> pure (lookupEnv env v)
+  Let v e e' -> do
+    x <- sample' e
+    sample (extendEnv v x env) e'
+  Not e -> not <$> sample' e
+  Neg e -> negate <$> sample' e
+  Abs e -> abs <$> sample' e
+  Sig e -> signum <$> sample' e
+  Exp e -> exp <$> sample' e
+  Log e -> log <$> sample' e
+  Add a b -> (+) <$> sample' a <*> sample' b
+  Mul a b -> (*) <$> sample' a <*> sample' b
 
-    Less a b -> zipWith (<) <$> sample' a <*> sample' b
+  Less a b -> (<) <$> sample' a <*> sample' b
 
-    If c a b -> zipWith3 ifThenElse <$> sample' c <*> sample' a <*> sample' b
+  If c a b -> ifThenElse <$> sample' c <*> sample' a <*> sample' b
 
-    Map f a -> fmap f <$> sample' a
-    App f a b -> zipWith f <$> sample' a <*> sample' b
-    Alt a b -> sample' a <|> sample' b
-    Join a -> do
-      a' <- sample' a
-      join <$> traverse sample' a'
-  | otherwise = pure []
-  where sample' :: Expr a -> IO [a]
-        sample' = sample n env
+  Map f a -> f <$> sample' a
+  App f a b -> f <$> sample' a <*> sample' b
+  Alt a b -> sample' a <|> sample' b
+  Join a -> do
+    a' <- sample' a
+    sample' a'
+  where sample' :: Expr a -> IO a
+        sample' = sample env
         ifThenElse c a b = if c then a else b
 
 histogramFrom :: Real a => a -> a -> [a] -> [Int]


### PR DESCRIPTION
Taking multiple samples at a time requires us to take care not to accidentally multiply the result sets. This is handled incorrectly by `Join`, which ends up producing the square of the _n_ parameter.

To resolve that, we just take a single sample at a time, and provide a convenience for sequencing multiple such samples where desired.
